### PR TITLE
Allow coexistance of each packege

### DIFF
--- a/assets/xremap-gnome-bin/PKGBUILD.tmpl
+++ b/assets/xremap-gnome-bin/PKGBUILD.tmpl
@@ -27,6 +27,10 @@ package() {
 	install -Dm644 zsh_completions "${pkgdir}/usr/share/zsh/site-functions/_xremap"
 	install -Dm644 fish_completions "${pkgdir}/usr/share/fish/vendor_completions.d/xremap.fish"
 	install -Dm644 bash_completions "${pkgdir}/usr/share/bash-completion/completions/xremap"
-	install -Dm755 xremap "${pkgdir}/usr/bin/xremap"
+	install -Dm755 xremap "${pkgdir}/usr/bin/xremap-gnome"
 	install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/xremap-gnome-bin/LICENSE"
+
+	if [ ! -L /usr/bin/xremap ]; then
+	  ln -sfT xremap-gnome "${pkgdir}/usr/bin/xremap"
+	fi
 }

--- a/assets/xremap-hypr-bin/PKGBUILD.tmpl
+++ b/assets/xremap-hypr-bin/PKGBUILD.tmpl
@@ -13,5 +13,9 @@ sha256sums_x86_64=('{{.SHA256Sum}}')
 package() {
   cd "$srcdir/"
 
-  install -Dm755 xremap "${pkgdir}/usr/bin/xremap"
+  install -Dm755 xremap "${pkgdir}/usr/bin/xremap-hypr"
+
+  if [ ! -L /usr/bin/xremap ]; then
+    ln -sfT xremap-hypr "${pkgdir}/usr/bin/xremap"
+  fi
 }

--- a/assets/xremap-wlroots-bin/PKGBUILD.tmpl
+++ b/assets/xremap-wlroots-bin/PKGBUILD.tmpl
@@ -13,5 +13,9 @@ sha256sums_x86_64=('{{.SHA256Sum}}')
 package() {
   cd "$srcdir/"
 
-  install -Dm755 xremap "${pkgdir}/usr/bin/xremap"
+  install -Dm755 xremap "${pkgdir}/usr/bin/xremap-wlroots"
+
+  if [ ! -L /usr/bin/xremap ]; then
+    ln -sfT xremap-wlroots "${pkgdir}/usr/bin/xremap"
+  fi
 }

--- a/assets/xremap-x11-bin/PKGBUILD.tmpl
+++ b/assets/xremap-x11-bin/PKGBUILD.tmpl
@@ -14,5 +14,9 @@ sha256sums_x86_64=('{{.SHA256Sum}}')
 package() {
   cd "$srcdir/"
 
-  install -Dm755 xremap "${pkgdir}/usr/bin/xremap"
+  install -Dm755 xremap "${pkgdir}/usr/bin/xremap-x11"
+
+  if [ ! -L /usr/bin/xremap ]; then
+    ln -sfT xremap-x11 "${pkgdir}/usr/bin/xremap"
+  fi
 }


### PR DESCRIPTION
Resolves #49.

First package's symlink will be preserved because removing other package's file is not permitted.

Idk whether I need to change from
```
provides=('xremap')
```
to
```
provides=('xremap', 'xremap-wlroots')
```
. So please consider it.