### PR TITLE
Integrate xremap-niri-bin package

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ make go-run
 ## Packages
 
 * https://aur.archlinux.org/packages/xremap-gnome-bin
+* https://aur.archlinux.org/packages/xremap-niri-bin
 * https://aur.archlinux.org/packages/xremap-hypr-bin
 * https://aur.archlinux.org/packages/xremap-wlroots-bin
 * https://aur.archlinux.org/packages/xremap-x11-bin

--- a/assets/xremap-niri-bin/.SRCINFO.tmpl
+++ b/assets/xremap-niri-bin/.SRCINFO.tmpl
@@ -1,0 +1,18 @@
+pkgbase = xremap-niri-bin
+	pkgdesc = Dynamic key remapper for X11 and Wayland (Niri Wayland Version)
+	pkgver = {{.Pkgver}}
+	pkgrel = 1
+	url = https://github.com/xremap/xremap
+	arch = x86_64
+	arch = aarch64
+	license = MIT
+	provides = xremap
+	options = !debug
+	source = LICENSE-{{.Pkgver}}::https://raw.githubusercontent.com/xremap/xremap/v{{.Pkgver}}/LICENSE
+	sha256sums = 60365594c733128ba50f05de00c4a6f07fed0a6e8bbd93817f39ded3980f7343
+	source_x86_64 = xremap-niri-bin-{{.Pkgver}}-x86_64.zip::https://github.com/xremap/xremap/releases/download/v{{.Pkgver}}/xremap-linux-x86_64-niri.zip
+	sha256sums_x86_64 = {{.SHA256Sum}}
+	source_aarch64 = xremap-niri-bin-{{.Pkgver}}-aarch64.zip::https://github.com/xremap/xremap/releases/download/v{{.Pkgver}}/xremap-linux-aarch64-niri.zip
+	sha256sums_aarch64 = {{.SHA256SumAarch64}}
+
+pkgname = xremap-niri-bin

--- a/assets/xremap-niri-bin/PKGBUILD.tmpl
+++ b/assets/xremap-niri-bin/PKGBUILD.tmpl
@@ -1,0 +1,33 @@
+# Maintainer: Qingxu <me@linioi.com>
+# Maintainer: k0kubun <takashikkbn@gmail.com>
+pkgname=xremap-niri-bin
+pkgdesc='Dynamic key remapper for X11 and Wayland (Niri Wayland Version)'
+pkgver={{.Pkgver}}
+pkgrel=1
+
+provides=('xremap')
+license=('MIT')
+url='https://github.com/xremap/xremap'
+arch=('x86_64' 'aarch64')
+options=('!debug')
+
+source=("LICENSE-$pkgver::https://raw.githubusercontent.com/xremap/xremap/v$pkgver/LICENSE")
+sha256sums=('60365594c733128ba50f05de00c4a6f07fed0a6e8bbd93817f39ded3980f7343')
+
+source_x86_64=("$pkgname-$pkgver-x86_64.zip::https://github.com/xremap/xremap/releases/download/v$pkgver/xremap-linux-x86_64-niri.zip")
+sha256sums_x86_64=('{{.SHA256Sum}}')
+
+source_aarch64=("$pkgname-$pkgver-aarch64.zip::https://github.com/xremap/xremap/releases/download/v$pkgver/xremap-linux-aarch64-niri.zip")
+sha256sums_aarch64=('{{.SHA256SumAarch64}}')
+
+package() {
+	cd "$srcdir/"
+	./xremap --completions zsh > zsh_completions
+	./xremap --completions fish > fish_completions
+	./xremap --completions bash > bash_completions
+	install -Dm644 zsh_completions "${pkgdir}/usr/share/zsh/site-functions/_xremap"
+	install -Dm644 fish_completions "${pkgdir}/usr/share/fish/vendor_completions.d/xremap.fish"
+	install -Dm644 bash_completions "${pkgdir}/usr/share/bash-completion/completions/xremap"
+	install -Dm755 xremap "${pkgdir}/usr/bin/xremap"
+	install -Dm644 "LICENSE-$pkgver" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}

--- a/cmd/aur-autoupdater/main.go
+++ b/cmd/aur-autoupdater/main.go
@@ -5,6 +5,7 @@ import "github.com/xremap/aur-autoupdater/internal/processor"
 func main() {
 	packages := []string{
 		"xremap-gnome-bin",
+		"xremap-niri-bin",
 		"xremap-hypr-bin",
 		"xremap-wlroots-bin",
 		"xremap-x11-bin",

--- a/internal/packageinfo/packageinfo.go
+++ b/internal/packageinfo/packageinfo.go
@@ -42,6 +42,27 @@ var PackageInfos = map[string]PackageInfo{
 			SrcinfoTemplateFilepath:  "assets/xremap-gnome-bin/.SRCINFO.tmpl",
 		},
 	},
+	"xremap-niri-bin": {
+		Name: "xremap-niri-bin",
+		GitHubInfo: GitHubInfo{
+			Owner: "xremap",
+			Repo:  "xremap",
+			ReleaseAssetURL: func(version string) string {
+				return fmt.Sprintf("https://github.com/xremap/xremap/releases/download/v%s/xremap-linux-x86_64-niri.zip", version)
+			},
+		},
+		GitHubInfoAarch64: GitHubInfo{
+			Owner: "xremap",
+			Repo:  "xremap",
+			ReleaseAssetURL: func(version string) string {
+				return fmt.Sprintf("https://github.com/xremap/xremap/releases/download/v%s/xremap-linux-aarch64-niri.zip", version)
+			},
+		},
+		PkgbuildInfo: PkgbuildInfo{
+			PkgbuildTemplateFilepath: "assets/xremap-niri-bin/PKGBUILD.tmpl",
+			SrcinfoTemplateFilepath:  "assets/xremap-niri-bin/.SRCINFO.tmpl",
+		},
+	},
 	"xremap-hypr-bin": {
 		Name: "xremap-hypr-bin",
 		GitHubInfo: GitHubInfo{


### PR DESCRIPTION
Integrate xremap-niri-bin package per https://github.com/xremap/aur-autoupdater/discussions/72#discussioncomment-16497457.

Note on LICENSE checksum:
The current template hardcodes the checksum for the LICENSE file, but the file itself is not included in the template. This could become a problem in the future if the license ever changes. A more robust solution would be to compute the checksum dynamically in the Go script, but since I'm not very familiar with Go, I've kept the existing approach for now. Given that the LICENSE file is unlikely to change, this should be acceptable as an initial step.
 